### PR TITLE
Adding extension to allow for Interface->Definitely conversion

### DIFF
--- a/wimm.Guards.Types.Tests/ExtensionTests.cs
+++ b/wimm.Guards.Types.Tests/ExtensionTests.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace wimm.Guards.Types.Tests
+{
+    public class ExtensionTests
+    {
+        [Fact]
+        public void ToDefinitely_NullObject_Throws()
+        {
+            var input = null as IEnumerable<string>;
+            Assert.Throws<ArgumentNullException>(() => input.ToDefinitely());
+        }
+
+        [Fact]
+        public void ToDefinitely_ValidInterface_ReturnValueRefEqualsInput()
+        {
+            var input = new List<string> { "Doot" } as IEnumerable<string>;
+            var res = input.ToDefinitely();
+
+            Assert.Same(input, res.Value);
+        }
+
+        [Fact]
+        public void ToDefinitely_ValidClass_ReturnValueRefEqualsInput()
+        {
+            var input = new List<string> { "DootDoot " };
+            var res = input.ToDefinitely();
+
+            Assert.Same(input, res.Value);
+        }
+
+    }
+
+
+}

--- a/wimm.Guards.Types/Definitely.cs
+++ b/wimm.Guards.Types/Definitely.cs
@@ -8,7 +8,7 @@ namespace wimm.Guards.Types
         public T Value => _set
             ? _value
             : throw new InvalidOperationException(
-                $"{nameof(Value)} was not set. You have default initialized this struct.");
+                $"{nameof(Value)} was not set. You have default initialized this {nameof(Definitely<T>)}.");
 
         private readonly bool _set;
         private readonly T _value;

--- a/wimm.Guards.Types/Extensions.cs
+++ b/wimm.Guards.Types/Extensions.cs
@@ -1,11 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace wimm.Guards.Types
+﻿namespace wimm.Guards.Types
 {
+    /// <summary>
+    /// Extensions for constructing and manipulating Guards.Types
+    /// </summary>
     public static class Extensions
     {
         /// <summary>
@@ -16,7 +13,8 @@ namespace wimm.Guards.Types
         /// inheritance heirarchy and we don't want to have to expose a public constructor (for now). 
         /// [Conditional](PublicConstructor)
         /// </remarks>
-        /// <returns> A <see cref="Definitely{T}"/> containing the object <paramref name="toConvert"/> </returns>
+        /// <returns> A <see cref="Definitely{T}"/> containing a reference to <paramref name="toConvert"/> 
+        /// </returns>
         public static Definitely<T> ToDefinitely<T>(this T toConvert) where T : class
         {
             return new Definitely<T>(toConvert);

--- a/wimm.Guards.Types/Extensions.cs
+++ b/wimm.Guards.Types/Extensions.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace wimm.Guards.Types
+{
+    public static class Extensions
+    {
+        /// <summary>
+        /// Method for converting types into definitely types. Mostly for interfaces.
+        /// </summary>
+        /// <remarks> Generally this should only be necessary for interface classes to ensure they aren't null
+        /// the C# language doesn't allow implicit conversions to or from interfaces other than up the 
+        /// inheritance heirarchy and we don't want to have to expose a public constructor (for now). 
+        /// [Conditional](PublicConstructor)
+        /// </remarks>
+        /// <returns> A <see cref="Definitely{T}"/> containing the object <paramref name="toConvert"/> </returns>
+        public static Definitely<T> ToDefinitely<T>(this T toConvert) where T : class
+        {
+            return new Definitely<T>(toConvert);
+        }
+    }
+}

--- a/wimm.Guards.Types/wimm.Guards.Types.csproj
+++ b/wimm.Guards.Types/wimm.Guards.Types.csproj
@@ -2,6 +2,12 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <Version>0.1.0</Version>
+    <Copyright>Chris Nantau &amp; Thomas Showers</Copyright>
+    <PackageProjectUrl>https://github.com/wareismymind/Guards.Types</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/wareismymind/Guards.Types</RepositoryUrl>
+    <RepositoryType>Git</RepositoryType>
+    <PackageTags>Guards, Guardian, Validation,Arguments, wareismymind, wimm</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Pretty simple commit. 

Adding an extension method .ToDefinitely that allows conversion into a definitely from an interface without making the ctor public. Documentation to come for the remainder of the initial code